### PR TITLE
Fix bash Instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Next, you should add the class repository as an upstream git repo:
 
 ```bash
 $ git remote add upstream https://github.com/msu/csci-366-spring2021.git
-$ git pull upstream main
-$ git push origin main
+$ git pull upstream master
+$ git push origin master
 ```
 This will synchronize your private repository with the class repository.
 
 When you want to get an update from the public class repository you can run this command:
 
 ```
-$ git pull upstream main
+$ git pull upstream master
 ```
 
 ## Homeworks


### PR DESCRIPTION
## Overview
The default branch name for [`msu/csci-366-spring2021`](https://github.com/msu/csci-366-spring2021) is `master`. 

The following code returns an error:
```bash
$ git pull upstream main
fatal: couldn't find remote ref main
```

### Updates
Thus, I have updated the bash code instructions in the [`README.md`](https://github.com/msu/csci-366-spring2021/blob/master/README.md) to target the `master` branch:
```bash
$ git remote add upstream https://github.com/msu/csci-366-spring2021.git
$ git pull upstream master
```

### P.S.

I also updated the line which pushes to the origin branch to `master`